### PR TITLE
Update kevinburke/rest to latest master

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -110,9 +110,9 @@ func (e *errorServer) Serve500(w http.ResponseWriter, r *http.Request) {
 }
 
 func registerErrorHandlers(e *errorServer) {
-	rest.RegisterHandler(401, e.Serve401)
-	rest.RegisterHandler(403, e.Serve403)
-	rest.RegisterHandler(404, e.Serve404)
-	rest.RegisterHandler(405, e.Serve405)
-	rest.RegisterHandler(500, e.Serve500)
+	rest.RegisterHandler(401, http.HandlerFunc(e.Serve401))
+	rest.RegisterHandler(403, http.HandlerFunc(e.Serve403))
+	rest.RegisterHandler(404, http.HandlerFunc(e.Serve404))
+	rest.RegisterHandler(405, http.HandlerFunc(e.Serve405))
+	rest.RegisterHandler(500, http.HandlerFunc(e.Serve500))
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -86,10 +86,10 @@
 			"revisionTime": "2016-10-26T22:56:18Z"
 		},
 		{
-			"checksumSHA1": "4kX1o0vgbQaSUikXnFfPr4zmNOA=",
+			"checksumSHA1": "pRZoJEa1gpLB05roBsF7xKH14os=",
 			"path": "github.com/kevinburke/rest",
-			"revision": "3e1a181ba70d885d80a05a330225d01e36d1ff23",
-			"revisionTime": "2016-10-29T15:46:50Z"
+			"revision": "03864faadc09165226fa75846ef31ab00944c17c",
+			"revisionTime": "2017-01-05T01:36:19Z"
 		},
 		{
 			"checksumSHA1": "I4njd26dG5hxFT2nawuByM4pxzY=",


### PR DESCRIPTION
At some point the signature of RegisterErrorHandler changed from (int,
HandlerFunc) to (int, Handler), which is more flexible. Unfortunately the code
here didn't change.

We didn't notice the build failure because an older version of kevinburke/rest
was being vendored. In any case, let's fix it and update the vendored
dependency.

Fixes #21.